### PR TITLE
Fix the `clear_app` command for Django 1.8

### DIFF
--- a/ixdjango/management/commands/clear_app.py
+++ b/ixdjango/management/commands/clear_app.py
@@ -34,6 +34,7 @@ class Command(BaseCommand):
     """
 
     help = ('Cleans the specified applications\' tables to a pristine state.')
+    args = '<app_label> <app_label> ... '
 
     def handle(self, *targets, **options):
         verbosity = int(options['verbosity'])


### PR DESCRIPTION
Django 1.8 introduced a breaking change for management commands
which only take positional arguments (they moved from `optparse`
to `argparse`). Since the `clear_app` command takes a series of
app names as positional arguments, the command is broken when
used in a Django 1.8 project.

This change applies the suggested fix (see https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/#django.core.management.BaseCommand.args)
(although it's worth noting that the command's help is not very
helpful even with this change).