### PR TITLE
Make sure management commands works with Django 2

### DIFF
--- a/ixdjango/management/commands/deploy.py
+++ b/ixdjango/management/commands/deploy.py
@@ -54,6 +54,4 @@ class Command(BaseCommand):
                     # pylint:enable=unbalanced-tuple-unpacking
                 else:
                     (cmd, args) = cmd
-            # interactive=False is the same as --noinput.
-            kwargs.setdefault('interactive', False)
             management.call_command(cmd, *args, **kwargs)


### PR DESCRIPTION
Django 2 validates management command options and sending in interactive=False by default will not work for all commands. Options for each command should be managed by itself now.