### PR TITLE
Remove interactive=False for loadixfixtures command

### DIFF
--- a/ixdjango/management/commands/loadixfixtures.py
+++ b/ixdjango/management/commands/loadixfixtures.py
@@ -42,8 +42,7 @@ class Command(BaseCommand):
             print("Loading IX_FIXTURES: {0}".format(','.join(ix_fixtures)))
             management.call_command(
                 "loaddata",
-                *ix_fixtures,
-                interactive=False
+                *ix_fixtures
             )
         else:
             print("loadixfixtures does nothing unless settings.IX_FIXTURES "


### PR DESCRIPTION
Interactive is not a valid option for commands deriving from `BaseCommand` with Django 2 and above.